### PR TITLE
Test/hotfix

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -178,7 +178,7 @@ class App extends Component {
                 path="/favorites"
                 exact
                 render={() => {
-                  return <ListingCardContainer listings={favorites}/>
+                  return <ListingCardContainer listings={favorites} />
                 }}
               />
               <Route

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -112,6 +112,8 @@ class App extends Component {
   findListing = (listingId) => {
     return this.state.listings.find(listing => {
       return listing.listing_id === parseInt(listingId)
+    }) || this.state.favorites.find(listing => {
+      return listing.listing_id === parseInt(listingId)
     })
   }
 
@@ -176,7 +178,7 @@ class App extends Component {
                 path="/favorites"
                 exact
                 render={() => {
-                  return <ListingCardContainer listings={favorites} />
+                  return <ListingCardContainer listings={favorites}/>
                 }}
               />
               <Route


### PR DESCRIPTION
# Description

Please include a summary of the change.

Resolved bug identified in the App component generating Listing Cards saved to favorites.  If the card is in the favorites but was not in the most recently searched Area, then it will not be in the states' Listings property which will cause it to crash when clicking on that card's view details button.  

## Type of change

Please delete options that are not relevant.

- [X] Bug fix or refactor (change which fixes an issue)

## Checklist:

- [X] My code follows the Turing style guidelines
- [X] I have performed a self-review of my own code
- [X] I have commented my code if necessary
